### PR TITLE
feat: update minimum ios version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/torusresearch/tss-client-swift.git",
         "state": {
           "branch": null,
-          "revision": "4eadb32baed827d5e0600ee4f5c099259c45631c",
-          "version": "5.0.0"
+          "revision": "6f00e4e03184a77eea0330b5b8d092d1452b9eb4",
+          "version": "5.0.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/tkey/curvelib.swift",
         "state": {
           "branch": null,
-          "revision": "9f88bd5e56d1df443a908f7a7e81ae4f4d9170ea",
-          "version": "1.0.1"
+          "revision": "432bf1abe7ff505fc2ac9fcf697341ff5b2dc6d0",
+          "version": "2.0.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/socketio/socket.io-client-swift",
         "state": {
           "branch": null,
-          "revision": "af5ce97b755d964235348d96f6db5cbdcbe334a5",
-          "version": "16.0.1"
+          "revision": "42da871d9369f290d6ec4930636c40672143905b",
+          "version": "16.1.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/daltoniam/Starscream",
         "state": {
           "branch": null,
-          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
-          "version": "4.0.4"
+          "revision": "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
+          "version": "4.0.8"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/torusresearch/tss-client-swift.git",
         "state": {
           "branch": null,
-          "revision": "40246d5e3ff1d2c97d41846576f7a81d58858981",
-          "version": "4.0.0"
+          "revision": "4eadb32baed827d5e0600ee4f5c099259c45631c",
+          "version": "5.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Web3SwiftMpcProvider",
-    platforms: [.iOS(.v13), .macOS(.v11)],
+    platforms: [.iOS(.v14), .macOS(.v11)],
     products: [
         .library(
             name: "Web3SwiftMpcProvider",
@@ -14,8 +14,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/argentlabs/web3.swift", from:"1.6.0"),
-        .package(url: "https://github.com/torusresearch/tss-client-swift.git", from: "4.0.0"),
-        .package(url: "https://github.com/tkey/curvelib.swift", from: "1.0.1"),
+        .package(url: "https://github.com/torusresearch/tss-client-swift.git", from: "5.0.0"),
+        .package(url: "https://github.com/tkey/curvelib.swift", from: "2.0.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/argentlabs/web3.swift", from:"1.6.0"),
-        .package(url: "https://github.com/torusresearch/tss-client-swift.git", from: "5.0.0"),
+        .package(url: "https://github.com/torusresearch/tss-client-swift.git", from: "5.0.1"),
         .package(url: "https://github.com/tkey/curvelib.swift", from: "2.0.0"),
     ],
     targets: [

--- a/web3-mpc-provider-swift.podspec
+++ b/web3-mpc-provider-swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "web3-mpc-provider-swift"
-  spec.version      = "4.0.0"
+  spec.version      = "5.0.0"
   spec.ios.deployment_target = '13.0'
   spec.summary      = "MPC TSS Client"
   spec.homepage     = "https://web3auth.io/"
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.source       = { :git => "https://github.com/tkey/web3-swift-mpc-provider.git", :tag => spec.version }
   spec.source_files = "Sources/**/*.{swift,h,c}"
   spec.dependency 'web3.swift', '~> 1.6.0'
-  spec.dependency 'tss-client-swift', '4.0.0'
-  spec.dependency 'curvelib.swift', '~> 1.0.1'
+  spec.dependency 'tss-client-swift', '5.0.0'
+  spec.dependency 'curvelib.swift', '~> 2.0.0'
   spec.module_name = "Web3SwiftMpcProvider"
 end

--- a/web3-mpc-provider-swift.podspec
+++ b/web3-mpc-provider-swift.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.source       = { :git => "https://github.com/tkey/web3-swift-mpc-provider.git", :tag => spec.version }
   spec.source_files = "Sources/**/*.{swift,h,c}"
   spec.dependency 'web3.swift', '~> 1.6.0'
-  spec.dependency 'tss-client-swift', '5.0.0'
+  spec.dependency 'tss-client-swift', '5.0.1'
   spec.dependency 'curvelib.swift', '~> 2.0.0'
   spec.module_name = "Web3SwiftMpcProvider"
 end


### PR DESCRIPTION
Requires tss-client-swift 5.0.0 released on cocoapods.
Release as 5.0.0
